### PR TITLE
Version 1.0.0-rc01

### DIFF
--- a/buildSrc/src/Versions.kt
+++ b/buildSrc/src/Versions.kt
@@ -6,7 +6,7 @@ const val SDK_TARGET = 28
 const val BUILD_TOOLS = "28.0.1"
 
 internal const val VERSION_ANDROID_PLUGIN = "3.1.3"
-const val VERSION_ANDROIDX = "1.0.0-beta01"
+const val VERSION_ANDROIDX = "1.0.0-rc01"
 const val VERSION_ESPRESSO = "3.1.0-alpha3"
 const val VERSION_RUNNER = "1.1.0-alpha3"
 const val VERSION_RULES = "1.1.0-alpha3"


### PR DESCRIPTION
Can you please release a version for `1.0.0-rc01`.

Thanks a lot for all your effort!

Using `collapsingtoolbarlayout-subtitle:1.0.0-beta01` with `material:1.0.0-rc01` causes NoSuchMethodError since `ThemeEnforcement.obtainStyledAttributes()` now has one more argument.

```
     Caused by: java.lang.NoSuchMethodError: No static method obtainStyledAttributes(Landroid/content/Context;Landroid/util/AttributeSet;[III)Landroid/content/res/TypedArray; in class Lcom/google/android/material/internal/ThemeEnforcement; or its super classes (declaration of 'com.google.android.material.internal.ThemeEnforcement' appears in /data/app/com.nimiq.app.safe.testnet.debug-bMTUiISgTEl9LhvHmHQrLQ==/base.apk:classes2.dex)
        at com.google.android.material.appbar.SubtitleCollapsingToolbarLayout.<init>(SubtitleCollapsingToolbarLayout.java:110)
        at com.google.android.material.appbar.SubtitleCollapsingToolbarLayout.<init>(SubtitleCollapsingToolbarLayout.java:100)
```